### PR TITLE
Fixes for status code on create, and using a pointer to unmarshal the brokerProperties JSON

### DIFF
--- a/azure.go
+++ b/azure.go
@@ -105,7 +105,7 @@ func (aq *AzureQueue) Send(item *Item) error {
 		return err
 	}
 
-	if resp.StatusCode == http.StatusOK {
+	if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusCreated {
 		return nil
 	}
 
@@ -164,9 +164,11 @@ func (aq *AzureQueue) Next() (*Item, error) {
 
 	brokerProperties := resp.Header.Get("BrokerProperties")
 
+    fmt.Println(brokerProperties) //ejh debug
+
 	var props map[string]interface{}
 
-	if err := json.Unmarshal([]byte(brokerProperties), props); err != nil {
+	if err := json.Unmarshal([]byte(brokerProperties), &props); err != nil {
 		return nil, fmt.Errorf("Error unmarshalling BrokerProperties: %v", err)
 	}
 	var (


### PR DESCRIPTION
I found I had to make a couple of changes to azure.go to successfully enqueue and dequeue items. 

`Send()` was failing when it received HTTP 201 response - I guess this is a change to the Azure behaviour.

Unmarshal of brokerProperties JSON failed with a `non-pointer map[string]interface{}` error.